### PR TITLE
export watchdogUsec and watchdogPing

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -4,7 +4,7 @@ function notifySocket() {
   return process.env.NOTIFY_SOCKET;
 }
 
-function watchdogUsec() {
+export function watchdogUsec() {
   return process.env.WATCHDOG_USEC;
 }
 
@@ -22,7 +22,7 @@ function notifySystemd(state: string): void {
   }
 }
 
-function watchdogPing(): void {
+export function watchdogPing(): void {
   notifySystemd('WATCHDOG=1');
 }
 


### PR DESCRIPTION
This is useful because I sometimes (randomly) run a little internal diagnostic before I send the watchdog notification (currently with sd-notify, switching to sd-notify-lite). If you don't do this, like Steve Yegge said:

> when your service says "oh yes, I'm fine", it may well be the case that the only thing still functioning in the server is the little component that knows how to say "I'm fine, roger roger, over and out" in a cheery droid voice

From https://gist.github.com/chitchcock/1281611